### PR TITLE
feat: added support for the new authenticator-based security

### DIFF
--- a/DependencyInjection/Security/Factory/Message/LtiPlatformMessageSecurityFactory.php
+++ b/DependencyInjection/Security/Factory/Message/LtiPlatformMessageSecurityFactory.php
@@ -23,17 +23,24 @@ declare(strict_types=1);
 namespace OAT\Bundle\Lti1p3Bundle\DependencyInjection\Security\Factory\Message;
 
 use OAT\Bundle\Lti1p3Bundle\Security\Authentication\Provider\Message\LtiPlatformMessageAuthenticationProvider;
+use OAT\Bundle\Lti1p3Bundle\Security\Authenticator\LtiPlatformMessageAuthenticator;
 use OAT\Bundle\Lti1p3Bundle\Security\Firewall\Message\LtiPlatformMessageAuthenticationListener;
 use OAT\Library\Lti1p3Core\Message\Launch\Validator\Platform\PlatformLaunchValidatorInterface;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Security\Http\FirewallMapInterface;
 
-class LtiPlatformMessageSecurityFactory implements SecurityFactoryInterface
+class LtiPlatformMessageSecurityFactory implements SecurityFactoryInterface, AuthenticatorFactoryInterface
 {
+    /**
+     * @deprecated since 6.1.1
+     */
     public function getPosition(): string
     {
         return 'pre_auth';
@@ -44,6 +51,14 @@ class LtiPlatformMessageSecurityFactory implements SecurityFactoryInterface
         return 'lti1p3_message_platform';
     }
 
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    /**
+     * @deprecated since 6.1.1
+     */
     public function create(
         ContainerBuilder $container,
         $id,
@@ -73,5 +88,30 @@ class LtiPlatformMessageSecurityFactory implements SecurityFactoryInterface
     public function addConfiguration(NodeDefinition $node): void
     {
         $node->children()->arrayNode('types')->scalarPrototype()->end();
+    }
+
+    public function createAuthenticator(
+        ContainerBuilder $container,
+        string $firewallName,
+        array $config,
+        string $userProviderId
+    ) {
+        $authenticatorId = sprintf('security.authenticator.%s.%s', $this->getKey(), $firewallName);
+
+        $authenticatorDefinition = new Definition(LtiPlatformMessageAuthenticator::class);
+        $authenticatorDefinition
+            ->setShared(false)
+            ->setArguments(
+                [
+                    new Reference(HttpMessageFactoryInterface::class),
+                    new Reference(FirewallMapInterface::class),
+                    new Reference(PlatformLaunchValidatorInterface::class),
+                    $firewallName,
+                    $config['types'] ?? []
+                ]
+            );
+        $container->setDefinition($authenticatorId, $authenticatorDefinition);
+
+        return $authenticatorId;
     }
 }

--- a/DependencyInjection/Security/Factory/Service/LtiServiceSecurityFactory.php
+++ b/DependencyInjection/Security/Factory/Service/LtiServiceSecurityFactory.php
@@ -23,17 +23,24 @@ declare(strict_types=1);
 namespace OAT\Bundle\Lti1p3Bundle\DependencyInjection\Security\Factory\Service;
 
 use OAT\Bundle\Lti1p3Bundle\Security\Authentication\Provider\Service\LtiServiceAuthenticationProvider;
+use OAT\Bundle\Lti1p3Bundle\Security\Authenticator\LtiServiceMessageAuthenticator;
 use OAT\Bundle\Lti1p3Bundle\Security\Firewall\Service\LtiServiceAuthenticationListener;
 use OAT\Library\Lti1p3Core\Security\OAuth2\Validator\RequestAccessTokenValidatorInterface;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Security\Http\FirewallMapInterface;
 
-class LtiServiceSecurityFactory implements SecurityFactoryInterface
+class LtiServiceSecurityFactory implements SecurityFactoryInterface, AuthenticatorFactoryInterface
 {
+    /**
+     * @deprecated since 6.1.1
+     */
     public function getPosition(): string
     {
         return 'pre_auth';
@@ -44,6 +51,14 @@ class LtiServiceSecurityFactory implements SecurityFactoryInterface
         return 'lti1p3_service';
     }
 
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    /**
+     * @deprecated since 6.1.1
+     */
     public function create(
         ContainerBuilder $container,
         $id,
@@ -73,5 +88,30 @@ class LtiServiceSecurityFactory implements SecurityFactoryInterface
     public function addConfiguration(NodeDefinition $node): void
     {
         $node->children()->arrayNode('scopes')->scalarPrototype()->end();
+    }
+
+    public function createAuthenticator(
+        ContainerBuilder $container,
+        string $firewallName,
+        array $config,
+        string $userProviderId
+    ) {
+        $authenticatorId = sprintf('security.authenticator.%s.%s', $this->getKey(), $firewallName);
+
+        $authenticatorDefinition = new Definition(LtiServiceMessageAuthenticator::class);
+        $authenticatorDefinition
+            ->setShared(false)
+            ->setArguments(
+                [
+                    new Reference(HttpMessageFactoryInterface::class),
+                    new Reference(FirewallMapInterface::class),
+                    new Reference(RequestAccessTokenValidatorInterface::class),
+                    $firewallName,
+                    $config['scopes'] ?? []
+                ]
+            );
+        $container->setDefinition($authenticatorId, $authenticatorDefinition);
+
+        return $authenticatorId;
     }
 }

--- a/Security/Authentication/Provider/Message/LtiPlatformMessageAuthenticationProvider.php
+++ b/Security/Authentication/Provider/Message/LtiPlatformMessageAuthenticationProvider.php
@@ -31,6 +31,9 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Throwable;
 
+/**
+ * @deprecated since 6.1.1, use LtiPlatformMessageAuthenticator instead
+ */
 class LtiPlatformMessageAuthenticationProvider implements AuthenticationProviderInterface
 {
     /** @var PlatformLaunchValidatorInterface */

--- a/Security/Authentication/Provider/Message/LtiToolMessageAuthenticationProvider.php
+++ b/Security/Authentication/Provider/Message/LtiToolMessageAuthenticationProvider.php
@@ -31,6 +31,9 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Throwable;
 
+/**
+ * @deprecated since 6.1.1, use LtiToolMessageAuthenticator instead
+ */
 class LtiToolMessageAuthenticationProvider implements AuthenticationProviderInterface
 {
     /** @var ToolLaunchValidatorInterface */

--- a/Security/Authentication/Provider/Service/LtiServiceAuthenticationProvider.php
+++ b/Security/Authentication/Provider/Service/LtiServiceAuthenticationProvider.php
@@ -30,6 +30,9 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Throwable;
 
+/**
+ * @deprecated since 6.1.1, use LtiServiceMessageAuthenticator instead
+ */
 class LtiServiceAuthenticationProvider implements AuthenticationProviderInterface
 {
     /** @var RequestAccessTokenValidatorInterface */

--- a/Security/Authenticator/LtiPlatformMessageAuthenticator.php
+++ b/Security/Authenticator/LtiPlatformMessageAuthenticator.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace OAT\Bundle\Lti1p3Bundle\Security\Authenticator;
+
+use OAT\Bundle\Lti1p3Bundle\Security\Authentication\Token\Message\LtiPlatformMessageSecurityToken;
+use OAT\Library\Lti1p3Core\Exception\LtiException;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\Platform\PlatformLaunchValidatorInterface;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Throwable;
+
+class LtiPlatformMessageAuthenticator extends AbstractAuthenticator
+{
+    /** @var HttpMessageFactoryInterface */
+    private $httpMessageFactory;
+
+    /** @var FirewallMap */
+    private $firewallMap;
+
+    /** @var PlatformLaunchValidatorInterface */
+    private $platformLaunchValidator;
+
+    /** @var string */
+    private $firewallName;
+
+    /** @var string[] */
+    private $types;
+
+    public function __construct(
+        HttpMessageFactoryInterface $httpMessageFactory,
+        FirewallMap $firewallMap,
+        PlatformLaunchValidatorInterface $platformLaunchValidator,
+        string $firewallName,
+        array $types = []
+    ) {
+        $this->httpMessageFactory = $httpMessageFactory;
+        $this->firewallMap = $firewallMap;
+        $this->platformLaunchValidator = $platformLaunchValidator;
+        $this->firewallName = $firewallName;
+        $this->types = $types;
+    }
+
+    public function supports(Request $request): ?bool
+    {
+        $firewallConfig = $this->firewallMap->getFirewallConfig($request);
+
+        if (null === $firewallConfig) {
+            return false;
+        }
+
+        return null !== $request->get('JWT') && $this->firewallName === $firewallConfig->getName();
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+        try {
+            $validationResult = $this->platformLaunchValidator
+                ->validateToolOriginatingLaunch($this->httpMessageFactory->createRequest($request));
+
+            if ($validationResult->hasError()) {
+                throw new LtiException($validationResult->getError());
+            }
+
+            if (null === $validationResult->getPayload()) {
+                throw new LtiException('LTI Message Payload required');
+            }
+
+            $messageType = $validationResult->getPayload()->getMessageType();
+
+            if (!empty($this->types) && !in_array($messageType, $this->types, true)) {
+                throw new BadRequestHttpException(sprintf('Invalid LTI message type %s', $messageType));
+            }
+
+            $passport = new SelfValidatingPassport(new UserBadge('lti', function () {
+                return new InMemoryUser('lti', null);
+            }));
+
+            $passport->setAttribute('validationResult', $validationResult);
+
+            return $passport;
+        } catch (Throwable $exception) {
+            throw new AuthenticationException(
+                sprintf('LTI platform message request authentication failed: %s', $exception->getMessage()),
+                $exception->getCode(),
+                $exception
+            );
+        }
+    }
+
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
+    {
+        return new LtiPlatformMessageSecurityToken($passport->getAttribute('validationResult'));
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return null;
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        $statusCode = $exception->getPrevious() instanceof BadRequestHttpException
+            ? Response::HTTP_BAD_REQUEST
+            : Response::HTTP_UNAUTHORIZED;
+
+        return new Response($exception->getMessage(), $statusCode);
+    }
+}

--- a/Security/Authenticator/LtiServiceMessageAuthenticator.php
+++ b/Security/Authenticator/LtiServiceMessageAuthenticator.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace OAT\Bundle\Lti1p3Bundle\Security\Authenticator;
+
+use OAT\Bundle\Lti1p3Bundle\Security\Authentication\Token\Service\LtiServiceSecurityToken;
+use OAT\Library\Lti1p3Core\Exception\LtiException;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\Platform\PlatformLaunchValidatorInterface;
+use OAT\Library\Lti1p3Core\Security\OAuth2\Validator\RequestAccessTokenValidatorInterface;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Throwable;
+
+class LtiServiceMessageAuthenticator extends AbstractAuthenticator
+{
+    /** @var HttpMessageFactoryInterface */
+    private $httpMessageFactory;
+
+    /** @var FirewallMap */
+    private $firewallMap;
+
+    /** @var RequestAccessTokenValidatorInterface */
+    private $requestAccessTokenValidator;
+
+    /** @var string */
+    private $firewallName;
+
+    /** @var string[] */
+    private $scopes;
+
+    public function __construct(
+        HttpMessageFactoryInterface $httpMessageFactory,
+        FirewallMap $firewallMap,
+        RequestAccessTokenValidatorInterface $requestAccessTokenValidator,
+        string $firewallName,
+        array $scopes = []
+    ) {
+        $this->httpMessageFactory = $httpMessageFactory;
+        $this->firewallMap = $firewallMap;
+        $this->requestAccessTokenValidator = $requestAccessTokenValidator;
+        $this->firewallName = $firewallName;
+        $this->scopes = $scopes;
+    }
+
+    public function supports(Request $request): ?bool
+    {
+        $firewallConfig = $this->firewallMap->getFirewallConfig($request);
+
+        if (null === $firewallConfig) {
+            return false;
+        }
+
+        return $this->firewallName === $firewallConfig->getName();
+    }
+
+    public function authenticate(Request $request)
+    {
+        try {
+            $validationResult = $this->requestAccessTokenValidator->validate(
+                $this->httpMessageFactory->createRequest($request),
+                $this->scopes
+            );
+
+            if ($validationResult->hasError()) {
+                throw new LtiException($validationResult->getError());
+            }
+
+            $passport = new SelfValidatingPassport(new UserBadge('lti', function () {
+                return new InMemoryUser('lti', null);
+            }));
+
+            $passport->setAttribute('validationResult', $validationResult);
+
+            return $passport;
+        } catch (Throwable $exception) {
+            throw new AuthenticationException(
+                sprintf('LTI service request authentication failed: %s', $exception->getMessage()),
+                $exception->getCode(),
+                $exception
+            );
+        }
+    }
+
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
+    {
+        return new LtiServiceSecurityToken($passport->getAttribute('validationResult'));
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return null;
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        return new Response($exception->getMessage(), Response::HTTP_UNAUTHORIZED);
+    }
+}

--- a/Security/Authenticator/LtiToolMessageAuthenticator.php
+++ b/Security/Authenticator/LtiToolMessageAuthenticator.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace OAT\Bundle\Lti1p3Bundle\Security\Authenticator;
+
+use OAT\Bundle\Lti1p3Bundle\Security\Authentication\Token\Message\LtiToolMessageSecurityToken;
+use OAT\Bundle\Lti1p3Bundle\Security\Exception\LtiToolMessageExceptionHandlerInterface;
+use OAT\Library\Lti1p3Core\Exception\LtiException;
+use OAT\Library\Lti1p3Core\Message\Launch\Validator\Tool\ToolLaunchValidatorInterface;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Throwable;
+
+class LtiToolMessageAuthenticator extends AbstractAuthenticator
+{
+    /** @var HttpMessageFactoryInterface */
+    private $httpMessageFactory;
+
+    /** @var FirewallMap */
+    private $firewallMap;
+
+    /** @var ToolLaunchValidatorInterface */
+    private $toolLaunchValidator;
+
+    /** @var LtiToolMessageExceptionHandlerInterface */
+    private $exceptionHandler;
+
+    /** @var string */
+    private $firewallName;
+
+    /** @var string[] */
+    private $types;
+
+
+    public function __construct(
+        HttpMessageFactoryInterface $httpMessageFactory,
+        FirewallMap $firewallMap,
+        ToolLaunchValidatorInterface $toolLaunchValidator,
+        LtiToolMessageExceptionHandlerInterface $exceptionHandler,
+        string $firewallName,
+        array $types = []
+    ) {
+        $this->httpMessageFactory = $httpMessageFactory;
+        $this->firewallMap = $firewallMap;
+        $this->toolLaunchValidator = $toolLaunchValidator;
+        $this->exceptionHandler = $exceptionHandler;
+        $this->firewallName = $firewallName;
+        $this->types = $types;
+    }
+
+    public function supports(Request $request): ?bool
+    {
+        $firewallConfig = $this->firewallMap->getFirewallConfig($request);
+
+        if (null === $firewallConfig) {
+            return false;
+        }
+
+        return null !== $request->get('id_token') && $this->firewallName === $firewallConfig->getName();
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+        try {
+            $validationResult = $this->toolLaunchValidator
+                ->validatePlatformOriginatingLaunch($this->httpMessageFactory->createRequest($request));
+
+            if ($validationResult->hasError()) {
+                throw new LtiException($validationResult->getError());
+            }
+
+            if (null === $validationResult->getPayload()) {
+                throw new LtiException('LTI Message Payload required');
+            }
+
+            $messageType = $validationResult->getPayload()->getMessageType();
+
+            if (!empty($this->types) && !in_array($messageType, $this->types, true)) {
+                throw new BadRequestHttpException(sprintf('Invalid LTI message type %s', $messageType));
+            }
+
+            $passport = new SelfValidatingPassport(new UserBadge('lti', function () {
+                return new InMemoryUser('lti', null);
+            }));
+
+            $passport->setAttribute('validationResult', $validationResult);
+
+            return $passport;
+        } catch (Throwable $exception) {
+            throw new AuthenticationException(
+                sprintf('LTI tool message request authentication failed: %s', $exception->getMessage()),
+                $exception->getCode(),
+                $exception
+            );
+        }
+    }
+
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
+    {
+        return new LtiToolMessageSecurityToken($passport->getAttribute('validationResult'));
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return null;
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        try {
+            return $this->exceptionHandler->handle($exception, $request);
+        } catch (Throwable $exception) {
+            $statusCode = $exception->getPrevious() instanceof BadRequestHttpException
+                ? Response::HTTP_BAD_REQUEST
+                : Response::HTTP_UNAUTHORIZED;
+
+            return new Response($exception->getMessage(), $statusCode);
+        }
+    }
+}

--- a/Security/Firewall/Message/LtiPlatformMessageAuthenticationListener.php
+++ b/Security/Firewall/Message/LtiPlatformMessageAuthenticationListener.php
@@ -31,6 +31,10 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterfac
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Http\Firewall\AbstractListener;
 
+/**
+ * @deprecated since 6.1.1, AuthenticatorManagerListener is used automatically instead by the new authenticator system,
+ * internal logic moved to LtiPlatformMessageAuthenticator.
+ */
 class LtiPlatformMessageAuthenticationListener extends AbstractListener
 {
     /** @var TokenStorageInterface */

--- a/Security/Firewall/Message/LtiToolMessageAuthenticationListener.php
+++ b/Security/Firewall/Message/LtiToolMessageAuthenticationListener.php
@@ -33,6 +33,10 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Http\Firewall\AbstractListener;
 use Throwable;
 
+/**
+ * @deprecated since 6.1.1, AuthenticatorManagerListener is used automatically instead by the new authenticator system,
+ * internal logic moved to LtiToolMessageAuthenticator.
+ */
 class LtiToolMessageAuthenticationListener extends AbstractListener
 {
     /** @var TokenStorageInterface */

--- a/Security/Firewall/Service/LtiServiceAuthenticationListener.php
+++ b/Security/Firewall/Service/LtiServiceAuthenticationListener.php
@@ -31,6 +31,10 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterfac
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Http\Firewall\AbstractListener;
 
+/**
+ * @deprecated since 6.1.1, AuthenticatorManagerListener is used automatically instead by the new authenticator system,
+ * internal logic moved to LtiServiceMessageAuthenticator.
+ */
 class LtiServiceAuthenticationListener extends AbstractListener
 {
     /** @var TokenStorageInterface */

--- a/Tests/Functional/Flow/Service/LtiServiceFlowTest.php
+++ b/Tests/Functional/Flow/Service/LtiServiceFlowTest.php
@@ -220,12 +220,12 @@ class LtiServiceFlowTest extends WebTestCase
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
         $this->assertStringContainsString(
-            'A Token was not found in the TokenStorage',
+            'Missing Authorization header',
             (string)$response->getContent()
         );
 
         $this->assertHasLogRecordThatContains(
-            'A Token was not found in the TokenStorage',
+            'Missing Authorization header',
             LogLevel::ERROR
         );
     }

--- a/Tests/Resources/Kernel/config/security.yaml
+++ b/Tests/Resources/Kernel/config/security.yaml
@@ -1,4 +1,5 @@
 security:
+    enable_authenticator_manager: true
     providers:
         users_in_memory: { memory: null }
 
@@ -16,7 +17,7 @@ security:
             stateless: true
             lti1p3_service: { scopes: ['allowed-scope'] }
         main:
-            anonymous: lazy
+            lazy: true
             provider: users_in_memory
 
     access_control:


### PR DESCRIPTION
Added support for the new authenticator-based Security system: https://symfony.com/doc/5.1/security/experimental_authenticators.html

Note:
- There is no breaking change, the previous security settings has to be still functional
- Old services marked as deprecated 

### Testing
Run `vendor/bin/phpunit`