### PR TITLE
fix: introduce a direct dependency on `symfony/security-core`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,16 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.3, 7.4]
-        coverage: ["true"]
+        php: [7.3, 7.4, 8.0, 8.1, 8.2]
         extra-composer-params: [""]
         include:
-        - php: 7.2
+        - php: 8.2
           coverage: "true"
-          extra-composer-params: "--prefer-lowest --prefer-stable"
-        - php: 8.0
-          coverage: "false" # PHPUnit 8.5.14 doesn't support code coverage under PHP 8
-          extra-composer-params: ""
 
     steps:
     - name: Checkout
@@ -46,7 +41,7 @@ jobs:
     - name: Psalm
       run: |
         ./vendor/bin/psalm --shepherd
-    
+
     - name: Coveralls
       if: ${{ matrix.coverage == 'true' }}
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1.2
+-----
+
+* Introduce a direct dependency on symfony/security-core
+
 6.1.1
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,14 @@
     "require": {
         "php": ">=7.2.0",
         "ext-json": "*",
-        "psr/log": "^1 || ^2 || ^3",
         "oat-sa/lib-lti1p3-core": "^6.0",
+        "psr/log": "^1 || ^2 || ^3",
         "symfony/framework-bundle": "^4.4 || ^5.1",
+        "symfony/psr-http-message-bridge": "^2.0",
         "symfony/security-bundle": "^4.4 || ^5.1",
+        "symfony/security-core": "^4.4|^5.4",
         "symfony/security-http": "^4.4.1 || ^5.1",
-        "symfony/yaml": "^4.4 || ^5.1",
-        "symfony/psr-http-message-bridge": "^2.0"
+        "symfony/yaml": "^4.4 || ^5.1"
     },
     "require-dev": {
         "phpunit/phpunit": "8.5.14",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/yaml": "^4.4 || ^5.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "8.5.14",
+        "phpunit/phpunit": "~8|~9",
         "php-coveralls/php-coveralls": "^2.4",
         "psalm/plugin-phpunit": "^0.15.1",
         "psr/log": "^1.1.0",


### PR DESCRIPTION
This PR locks a dependency on symfony/security-core.

We have to upgrade the bundle at some point soon in order to support the new Symfony security system.
> @deprecated Since symfony/security-bundle 5.3: The "security.authentication.manager" service is deprecated, use the new authenticator system instead.