### PR TITLE
chore: update third party libraries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,15 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 8.1, 8.2, 8.3 ]
+        php: [ 8.2, 8.3 ]
         extra-composer-params: [ "" ]
         include:
-          - php: 8.3
+          - php: 8.4
             coverage: "true"
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP & Composer
         uses: shivammathur/setup-php@v2

--- a/Repository/RegistrationRepository.php
+++ b/Repository/RegistrationRepository.php
@@ -63,7 +63,7 @@ class RegistrationRepository implements RegistrationRepositoryInterface
         return null;
     }
 
-    public function findByPlatformIssuer(string $issuer, string $clientId = null): ?RegistrationInterface
+    public function findByPlatformIssuer(string $issuer, ?string $clientId = null): ?RegistrationInterface
     {
         foreach ($this->registrations->all() as $registration) {
             if ($registration->getPlatform()->getAudience() === $issuer) {
@@ -80,7 +80,7 @@ class RegistrationRepository implements RegistrationRepositoryInterface
         return null;
     }
 
-    public function findByToolIssuer(string $issuer, string $clientId = null): ?RegistrationInterface
+    public function findByToolIssuer(string $issuer, ?string $clientId = null): ?RegistrationInterface
     {
         foreach ($this->registrations->all() as $registration) {
             if ($registration->getTool()->getAudience() === $issuer) {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "ext-json": "*",
         "league/oauth2-server": "^8.5 | ^9.2",
         "nyholm/psr7": "^1.8",
-        "oat-sa/lib-lti1p3-core": "dev-feat/TR-6514/php-84 as 7.2.1",
+        "oat-sa/lib-lti1p3-core": "7.2.2",
         "psr/log": "^1 || ^2 || ^3",
         "symfony/framework-bundle": "^6.4",
         "symfony/psr-http-message-bridge": "^2.1 || ^7.2",

--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,12 @@
     "require": {
         "php": ">=8.1.0",
         "ext-json": "*",
-        "league/oauth2-server": "^8.5",
+        "league/oauth2-server": "^8.5 | ^9.2",
         "nyholm/psr7": "^1.8",
-        "oat-sa/lib-lti1p3-core": "^7.0.2",
+        "oat-sa/lib-lti1p3-core": "dev-feat/TR-6514/php-84 as 7.2.1",
         "psr/log": "^1 || ^2 || ^3",
         "symfony/framework-bundle": "^6.4",
-        "symfony/psr-http-message-bridge": "^2.1",
+        "symfony/psr-http-message-bridge": "^2.1 || ^7.2",
         "symfony/security-bundle": "^6.4",
         "symfony/security-core": "^6.4",
         "symfony/security-http": "^6.4",
@@ -24,9 +24,9 @@
         "nesbot/carbon": "^2.72 || ^3.0",
         "php-coveralls/php-coveralls": "^2.4",
         "phpunit/phpunit": "~9",
-        "psalm/plugin-phpunit": "^0.18",
+        "psalm/plugin-phpunit": "^0.19",
         "symfony/browser-kit": "^6.4",
-        "vimeo/psalm": "^5.25"
+        "vimeo/psalm": "^5.25 || ^6.8"
     },
     "autoload": {
         "psr-4": {

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -20,21 +20,56 @@
         </ignoreFiles>
     </projectFiles>
     <issueHandlers>
-        <ReservedWord>
+        <ClassMustBeFinal errorLevel="suppress" />
+        <MissingOverrideAttribute errorLevel="suppress" />
+        <PossiblyUnusedMethod>
             <errorLevel type="suppress">
-                <file name="DependencyInjection/Configuration.php"/>
-                <file name="DependencyInjection/Lti1p3Extension.php"/>
+                <file name="DependencyInjection/Builder/RegistrationRepositoryBuilder.php" method="__construct"/>
+                <file name="DependencyInjection/Builder/RegistrationRepositoryBuilder.php" method="build"/>
+                <file name="Security/Authentication/Token/Message/LtiToolMessageSecurityToken.php" method="getState"/>
+                <file name="Security/Authentication/Token/Service/LtiServiceSecurityToken.php" method="getValidationResult"/>
+                <file name="Security/Authentication/Token/Service/LtiServiceSecurityToken.php" method="getRegistration"/>
+                <file name="Security/Authentication/Token/Service/LtiServiceSecurityToken.php" method="getScopes"/>
+                <file name="Security/Authentication/Token/Service/LtiServiceSecurityToken.php" method="getCredentials"/>
+                <file name="Security/Firewall/Message/LtiToolMessageAuthenticator.php" method="__construct"/>
+                <file name="Security/Firewall/Service/LtiServiceAuthenticator.php" method="__construct"/>
+                <file name="DependencyInjection/Builder/KeyChainRepositoryBuilder.php" method="__construct"/>
+                <file name="DependencyInjection/Builder/KeyChainRepositoryBuilder.php" method="build"/>
+                <file name="Security/Authentication/Token/Message/AbstractLtiMessageSecurityToken.php" method="getValidationResult"/>
+                <file name="Security/Authentication/Token/Message/AbstractLtiMessageSecurityToken.php" method="getRegistration"/>
+                <file name="Security/Authentication/Token/Message/AbstractLtiMessageSecurityToken.php" method="getCredentials"/>
+                <file name="Security/Firewall/Message/LtiPlatformMessageAuthenticator.php" method="__construct"/>
             </errorLevel>
-        </ReservedWord>
+        </PossiblyUnusedMethod>
+        <MoreSpecificReturnType>
+            <errorLevel type="suppress">
+                <file name="Security/Firewall/Message/LtiPlatformMessageAuthenticator.php" method="getJwtFromRequest"/>
+                <file name="Security/Firewall/Message/LtiToolMessageAuthenticator.php" method="getIdTokenFromRequest"/>
+            </errorLevel>
+        </MoreSpecificReturnType>
+        <LessSpecificReturnStatement>
+            <errorLevel type="suppress">
+                <file name="Security/Firewall/Message/LtiPlatformMessageAuthenticator.php" method="getJwtFromRequest"/>
+                <file name="Security/Firewall/Message/LtiToolMessageAuthenticator.php" method="getIdTokenFromRequest"/>
+            </errorLevel>
+        </LessSpecificReturnStatement>
+        <UnusedClass>
+            <errorLevel type="suppress">
+                <file name="Action/Jwks/JwksAction.php"/>
+                <file name="Action/Platform/Message/OidcAuthenticationAction.php"/>
+                <file name="Action/Platform/Service/OAuth2AccessTokenCreationAction.php"/>
+                <file name="Action/Tool/Message/OidcInitiationAction.php"/>
+                <file name="DependencyInjection/Security/Factory/Message/LtiPlatformMessageSecurityFactory.php"/>
+                <file name="DependencyInjection/Security/Factory/Message/LtiToolMessageSecurityFactory.php"/>
+                <file name="DependencyInjection/Security/Factory/Service/LtiServiceSecurityFactory.php"/>
+                <file name="Security/Exception/LtiToolMessageExceptionHandler.php"/>
+            </errorLevel>
+        </UnusedClass>
         <ArgumentTypeCoercion>
             <errorLevel type="suppress">
                 <file name="DependencyInjection/Configuration.php"/>
             </errorLevel>
         </ArgumentTypeCoercion>
-        <InternalMethod>
-            <errorLevel type="suppress">
-            </errorLevel>
-        </InternalMethod>
         <ParamNameMismatch>
             <errorLevel type="suppress">
                 <file name="DependencyInjection/Security/Factory/Message/LtiToolMessageSecurityFactory.php"/>
@@ -42,16 +77,6 @@
                 <file name="DependencyInjection/Security/Factory/Service/LtiServiceSecurityFactory.php"/>
             </errorLevel>
         </ParamNameMismatch>
-        <PossiblyNullReference>
-            <errorLevel type="suppress">
-                <file name="DependencyInjection/Configuration.php"/>
-            </errorLevel>
-        </PossiblyNullReference>
-        <PossiblyUndefinedMethod>
-            <errorLevel type="suppress">
-                <file name="DependencyInjection/Configuration.php"/>
-            </errorLevel>
-        </PossiblyUndefinedMethod>
         <UndefinedMethod>
             <errorLevel type="suppress">
                 <file name="DependencyInjection/Security/Factory/Message/LtiPlatformMessageSecurityFactory.php"/>
@@ -64,14 +89,6 @@
                 <file name="DependencyInjection/Configuration.php"/>
             </errorLevel>
         </UndefinedInterfaceMethod>
-        <MethodSignatureMismatch>
-            <errorLevel type="suppress">
-                <file name="Security/Authentication/Token/Message/AbstractLtiMessageSecurityToken.php"/>
-                <file name="Security/Authentication/Token/Message/LtiToolMessageSecurityToken.php"/>
-                <file name="Security/Authentication/Token/Service/LtiServiceSecurityToken.php"/>
-                <file name="Security/Authentication/Token/Message/LtiPlatformMessageSecurityToken.php"/>
-            </errorLevel>
-        </MethodSignatureMismatch>
     </issueHandlers>
     <mockClasses>
         <class name="PHPUnit\Framework\MockObject\MockObject"/>


### PR DESCRIPTION
# Add support for third party libraries 


## Description 
This PR extends the possibility to usethe  latest version for `league/oauth2-server` and `symfony/psr-http-message-bridge`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build workflow to use Ubuntu 24.04, expanded PHP version testing to include PHP 8.4, and upgraded GitHub Actions checkout version.
	- Adjusted dependency versions in composer configuration for broader compatibility.
	- Refined static analysis configuration to improve error suppression granularity.
- **Refactor**
	- Updated method signatures to explicitly allow nullable parameters in certain repository methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->