### PR TITLE
chore: upgrade LTI 1.3 libraries to versions that support PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "ext-json": "*",
         "league/oauth2-server": "^8.5 | ^9.2",
         "nyholm/psr7": "^1.8",
-        "oat-sa/lib-lti1p3-core": "7.2.2",
+        "oat-sa/lib-lti1p3-core": "^7.0",
         "psr/log": "^1 || ^2 || ^3",
         "symfony/framework-bundle": "^6.4",
         "symfony/psr-http-message-bridge": "^2.1 || ^7.2",


### PR DESCRIPTION
This pull request updates the dependency version for `oat-sa/lib-lti1p3-core` in the `composer.json` file. The version constraint has been changed from `7.2.2` to `^7.0`, allowing for greater flexibility in compatible versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the version constraint for a dependency to allow compatibility with a wider range of versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->